### PR TITLE
Issue with parameters not evaluating variables in Git Client

### DIFF
--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -100,9 +100,17 @@ steps:
   - ci-tools/copy-ssh-key:
       decode-params: '-di'
   # Configure Git Client
-  - orb-tools/configure-git:
-      user-name: <<parameters.git-name>>
-      user-email: <<parameters.git-email>>
+  - run:
+      name: Configure Git Client
+      command: |
+        if [ -z "<<parameters.git-name>>" ] || [ -z "<<parameters.git-email>>" ]; then
+            # No user name or email set, default to CIRCLE_USERNAME-based identifiers
+            git config --global user.name "$CIRCLE_USERNAME"
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+        else
+            git config --global user.name "<<parameters.git-name>>"
+            git config --global user.email "<<parameters.git-email>>"
+        fi
   # Install Tools
   - ci-tools/install-github-cli:
       version: '2.4.0'


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Git client isn't properly configuring and therefore the name and email aren't being set to the proper variables.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

- Removed orb command for a standard command