### PR TITLE
add missing php version

### DIFF
--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -7,8 +7,8 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1']
-    default: '7.4'
+    enum: ['7.4', '8.0', '8.1', '8.2']
+    default: '8.1'
   cms:
     description: "Type of CMS to run updates on."
     type: enum


### PR DESCRIPTION
Fixes an issues with using php 8.2 because of missing keys in the circleci orb