### PR TITLE
configuration is always checked out

### DIFF
--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -151,7 +151,7 @@ steps:
       steps:
         - ci-tools/install-wpcli
   # Download Configuration Repo
-  - unless:
+  - when:
       condition: <<parameters.run-local>>
       steps:
         - run:


### PR DESCRIPTION
Configuration is always attempted a checkout even when run local is set to false
https://app.circleci.com/pipelines/github/teachforall/portal/667/workflows/eb8cd879-3772-457c-8872-2d28d6c6b7f7/jobs/764