### PR TITLE
tw30009531 - Add PHP 8.4 to php-version enum

### DIFF
--- a/src/executors/acquia.yml
+++ b/src/executors/acquia.yml
@@ -2,7 +2,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   db-version:
     description: "Tag used for MySQL version. Image: mariadb"

--- a/src/executors/general.yml
+++ b/src/executors/general.yml
@@ -2,7 +2,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   db-version:
     description: "Tag used for MySQL version. Image: mariadb"

--- a/src/executors/kinsta.yml
+++ b/src/executors/kinsta.yml
@@ -2,7 +2,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   db-version:
     description: "Tag used for MySQL version. Image: mariadb"

--- a/src/executors/pantheon.yml
+++ b/src/executors/pantheon.yml
@@ -2,7 +2,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   db-version:
     description: "Tag used for MySQL version. Image: mariadb"

--- a/src/executors/wpengine.yml
+++ b/src/executors/wpengine.yml
@@ -2,7 +2,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   db-version:
     description: "Tag used for MySQL version. Image: mariadb"

--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -7,7 +7,7 @@ parameters:
   php-version:
     description: "Tag used for PHP version. Image: cimg/php"
     type: enum
-    enum: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    enum: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     default: '8.1'
   cms:
     description: "Type of CMS to run updates on."


### PR DESCRIPTION
Projects using PHP 8.4 (e.g. cimg/php:8.4) fail at config parsing because the enum only accepts up to 8.3. Updated all 5 executors and the run-update job parameter.
