### PR TITLE
Bump install-github-cli from 2.62.0 to 2.92.0

### DIFF
--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -131,7 +131,7 @@ steps:
         fi
   # Install Tools
   - ci-tools/install-github-cli:
-      version: '2.62.0'
+      version: '2.92.0'
   - when:
       condition:
         and:


### PR DESCRIPTION
@sean-e-dietrich 

The 2.62.0 bump in #44 did not actually fix the `gh pr edit` failure on the
  deprecated `projectCards` field. The real fix landed in cli/cli#10942
  ("Feature detect v1 projects on pr edit"), first released in gh v2.73.0
  (2025-05-19). Bumping to 2.92.0 (current latest stable).
  
