### PR TITLE
Add export-config parameter to gate drush cex step

### DIFF
--- a/src/commands/run-update.yml
+++ b/src/commands/run-update.yml
@@ -19,6 +19,17 @@ parameters:
   run-local:
     type: boolean
     default: false
+  export-config:
+    description: >
+      For Drupal sites: whether to run `drush cex -y` against the runner's
+      database after composer update. When true (default, backwards-compatible),
+      any config drift between the pulled DB and the committed config/
+      directory is captured in the resulting PR. Set false to skip the export
+      and keep the auto-PR scoped strictly to composer.json / composer.lock
+      changes — useful when config drift is reconciled through a separate
+      workflow and should not appear in automated update PRs.
+    type: boolean
+    default: true
 steps:
   - when:
       condition:
@@ -91,10 +102,12 @@ steps:
             command: project-versions diff composer /tmp/output.md /tmp/before_update.json /tmp/after_update.json
         - when:
             condition:
-              or:
-                - equal: ["drupal", <<parameters.cms>>]
-                - equal: ["drupal8", <<parameters.cms>>]
-                - equal: ["drupal9", <<parameters.cms>>]
+              and:
+                - <<parameters.export-config>>
+                - or:
+                    - equal: ["drupal", <<parameters.cms>>]
+                    - equal: ["drupal8", <<parameters.cms>>]
+                    - equal: ["drupal9", <<parameters.cms>>]
             steps:
               - run:
                   name: Drush Export

--- a/src/jobs/run-update.yml
+++ b/src/jobs/run-update.yml
@@ -107,6 +107,17 @@ parameters:
     default: false
     description: "Cancel the step if there is a PR already opened"
     type: boolean
+  export-config:
+    description: >
+      For Drupal sites: whether to run `drush cex -y` against the runner's
+      database after composer update. When true (default, backwards-compatible),
+      any config drift between the pulled DB and the committed config/
+      directory is captured in the resulting PR. Set false to skip the export
+      and keep the auto-PR scoped strictly to composer.json / composer.lock
+      changes — useful when config drift is reconciled through a separate
+      workflow and should not appear in automated update PRs.
+    type: boolean
+    default: true
   resource-class:
     type: enum
     enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
@@ -331,6 +342,7 @@ steps:
                   update-method: <<parameters.update-method>>
                   docroot: <<parameters.docroot>>
                   composer-version: <<parameters.composer-version>>
+                  export-config: <<parameters.export-config>>
   - when:
       condition:
         equal: ["drupal", <<parameters.cms>>]
@@ -343,6 +355,7 @@ steps:
                   update-method: <<parameters.update-method>>
                   docroot: <<parameters.docroot>>
                   composer-version: <<parameters.composer-version>>
+                  export-config: <<parameters.export-config>>
   - when:
       condition:
         equal: ["wordpress", <<parameters.cms>>]


### PR DESCRIPTION
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/30056534
- [X] Was AI used in this pull request?

### Motivation, issues

The `run-update` command currently runs `drush cex -y` against the runner's local DB (a copy of live, pulled via `pull-db-pantheon`) immediately after `composer update`. This captures any drift between live's DB and the repo's `config/` and materializes that drift in the resulting auto-PR.

That behavior fits one workflow well and another poorly:

- **Loose config governance** — live UI tweaks are an accepted source of config, weekly auto-updates double as a "sync from live" mechanism. The cex side effect is part of the value of the PR.
- **Tight config governance** — config flows local → main → deploy → `drush cim` on live, with main as the source of truth. The cex side effect is at best noise. When the runner snapshots live between "PR merged to main" and "`cim` ran on live," the cex produces deletion lines in the auto-PR for config that's on main but not yet on live. Merging the auto-PR silently reverts that config — no merge conflict, since the deletion is mechanically clean.

We hit this on one of our Drupal sites: a contrib module enable and a `seckit` setting addition (both deliberately added on main) were proposed as deletions in the following week's auto-PR. Reverting them would have re-broken production. Caught by manual diff review; not a sustainable defense.

A parameter rather than an unconditional removal of the cex step preserves backwards compatibility for every existing consumer of this orb. Default `true` means zero behavior change for anyone who doesn't opt in.

### Description

Adds an `export-config` boolean parameter (default `true`) to the `run-update` job and command. The existing `when:` condition wrapping the `drush cex -y` step is extended to also require `export-config` to be true.

**Behavior:**

| `export-config` | Behavior on Drupal + composer sites |
|---|---|
| `true` (default) | `drush cex -y` runs after `composer update`. Current behavior preserved. |
| `false` | `drush cex -y` is omitted at config-resolution time. Auto-PR contains only composer-driven changes. |

No effect on Drupal + drush update-method (no cex step in that branch). No effect on WordPress. No effect on the existing `cms: drupal | drupal8 | drupal9` cms-type filter.

**Tested locally with the CircleCI CLI:**

1. `circleci orb pack src/` + `circleci orb validate` → orb is structurally valid.
2. Wrote a minimal test config that inlines the modified orb and invokes the `run-update` job twice — once with `export-config: true`, once with `false`. Ran `circleci config process` and inspected the resolved YAML:
- `export-config: true` → resolved config contains the `drush cex -y` step.
- `export-config: false` → resolved config does **not** contain the `drush cex -y` step.

End-to-end runtime testing (actual auto-update job with live DB pull, composer update, etc.) is out of scope for this PR since the parameter only gates an existing step on a `when:` condition — there is no new runtime path. The step either runs as before, or is omitted entirely at config-resolution time.

**How a consumer opts out:**

```yaml
workflows:
automated-updates:
jobs:
- cms-updates/run-update:
cms: drupal
# ... other parameters unchanged ...
export-config: false
```

**Separate concern noticed but not addressed in this PR:** 

The `drush cex` step runs after `composer update` but before any `drush updb`. Composer update only modifies code on disk — it does not migrate DB config via `hook_update_N`. So even on sites that *want* the cex behavior, the export captures live's pre-update DB state, not post-update state, and doesn't actually surface schema changes introduced by the module updates themselves. It only surfaces pre-existing drift. That's arguably a deeper bug worth a separate conversation, but it's outside the scope of this small change.
