### PR TITLE
Add AI-disclosure checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 -->
 
 ### Description
+- [ ] Was AI used in this pull request?
 
 <!---
   Describe your changes in detail, preferably in an imperative mood,


### PR DESCRIPTION
## Description
Adds the "Was AI used in this pull request?" disclosure checkbox to the top of this repo's PR description template, matching Kanopi's org-wide default.

## Why
This repo has its own custom PR template that predates the AI-disclosure checkbox now shipped in [kanopi/.github](https://github.com/kanopi/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md). This fills that gap so PR authors here are prompted the same way as repos using the default template.

## Steps to Validate
1. Open a new PR against this branch's target repo (or preview the template file) and confirm it now includes:
   `- [ ] Was AI used in this pull request?`
